### PR TITLE
Malloy 0.0.50

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,11 @@
       "license": "GPL-2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.7.1",
-        "@malloydata/malloy": "*"
+        "@malloydata/malloy": "*",
+        "debug": "^4.3.4"
       },
       "devDependencies": {
+        "@types/debug": "^4.1.8",
         "@types/node": "^14.11.2",
         "@typescript-eslint/eslint-plugin": "^5.51.0",
         "@typescript-eslint/parser": "^5.51.0",
@@ -348,9 +350,9 @@
       "dev": true
     },
     "node_modules/@malloydata/malloy": {
-      "version": "0.0.31",
-      "resolved": "https://registry.npmjs.org/@malloydata/malloy/-/malloy-0.0.31.tgz",
-      "integrity": "sha512-FBXSl2umvWX35Q6LEVY3b8n6JkCdKak5SQJtz++Q7Jpu1m5Qt5W9M8LRIsWqbDKxlxCpM48em9wAn4jiS5UShA==",
+      "version": "0.0.50",
+      "resolved": "https://registry.npmjs.org/@malloydata/malloy/-/malloy-0.0.50.tgz",
+      "integrity": "sha512-1gpn3hcAxv8TLATZsAfPAVf0GGsWsHYS/Sb0sjULYy4jEJhXB3xUksKh8KHJEN5GqXXQa4gl6v4SyWb9CN6NWg==",
       "dependencies": {
         "antlr4ts": "^0.5.0-alpha.4",
         "assert": "^2.0.0",
@@ -471,6 +473,15 @@
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
+    "node_modules/@types/debug": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.8.tgz",
+      "integrity": "sha512-/vPO1EPOs306Cvhwv7KfVfYvOJqA/S/AXjaHQiJboCZzcNDb+TIJFN9/2C9DZ//ijSKWioNyUxD792QmDJ+HKQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.11",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
@@ -486,6 +497,12 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
       "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==",
+      "dev": true
+    },
+    "node_modules/@types/ms": {
+      "version": "0.7.31",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
+      "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==",
       "dev": true
     },
     "node_modules/@types/node": {
@@ -1276,7 +1293,6 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -3281,8 +3297,7 @@
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/multistream": {
       "version": "4.1.0",
@@ -5141,9 +5156,9 @@
       }
     },
     "@malloydata/malloy": {
-      "version": "0.0.31",
-      "resolved": "https://registry.npmjs.org/@malloydata/malloy/-/malloy-0.0.31.tgz",
-      "integrity": "sha512-FBXSl2umvWX35Q6LEVY3b8n6JkCdKak5SQJtz++Q7Jpu1m5Qt5W9M8LRIsWqbDKxlxCpM48em9wAn4jiS5UShA==",
+      "version": "0.0.50",
+      "resolved": "https://registry.npmjs.org/@malloydata/malloy/-/malloy-0.0.50.tgz",
+      "integrity": "sha512-1gpn3hcAxv8TLATZsAfPAVf0GGsWsHYS/Sb0sjULYy4jEJhXB3xUksKh8KHJEN5GqXXQa4gl6v4SyWb9CN6NWg==",
       "requires": {
         "antlr4ts": "^0.5.0-alpha.4",
         "assert": "^2.0.0",
@@ -5249,6 +5264,15 @@
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
+    "@types/debug": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.8.tgz",
+      "integrity": "sha512-/vPO1EPOs306Cvhwv7KfVfYvOJqA/S/AXjaHQiJboCZzcNDb+TIJFN9/2C9DZ//ijSKWioNyUxD792QmDJ+HKQ==",
+      "dev": true,
+      "requires": {
+        "@types/ms": "*"
+      }
+    },
     "@types/json-schema": {
       "version": "7.0.11",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
@@ -5264,6 +5288,12 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
       "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==",
+      "dev": true
+    },
+    "@types/ms": {
+      "version": "0.7.31",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
+      "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==",
       "dev": true
     },
     "@types/node": {
@@ -5786,7 +5816,6 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
       "requires": {
         "ms": "2.1.2"
       }
@@ -7243,8 +7272,7 @@
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "multistream": {
       "version": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -21,17 +21,19 @@
   },
   "dependencies": {
     "@grpc/grpc-js": "^1.7.1",
-    "@malloydata/malloy": "*"
+    "@malloydata/malloy": "*",
+    "debug": "^4.3.4"
   },
   "devDependencies": {
+    "@types/debug": "^4.1.8",
+    "@types/node": "^14.11.2",
     "@typescript-eslint/eslint-plugin": "^5.51.0",
     "@typescript-eslint/parser": "^5.51.0",
     "grpc_tools_node_protoc_ts": "^5.3.2",
     "grpc-tools": "^1.11.2",
-    "pkg": "^5.8.0",
     "gts": "^3.1.1",
-    "typescript": "~4.7.0",
-    "@types/node": "^14.11.2"
+    "pkg": "^5.8.0",
+    "typescript": "~4.7.0"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/protos/services/v1/compiler.proto
+++ b/protos/services/v1/compiler.proto
@@ -70,7 +70,7 @@ message CompilerRequest {
   repeated string import_urls = 2;
   repeated string table_schemas = 3;
   SqlBlock sql_block = 4;
-  repeated string connections = 5;
+  string connection = 5;
 
   string content = 99;
 }

--- a/src/services/v1/compiler_runtime.ts
+++ b/src/services/v1/compiler_runtime.ts
@@ -21,12 +21,14 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+import debug from 'debug';
 import {
   LookupConnection,
   Connection,
   MalloyQueryData,
   SQLBlock,
   StructDef,
+  QueryRunStats,
 } from '@malloydata/malloy';
 
 // Import from auto-generated file
@@ -40,6 +42,8 @@ export class CompilerRuntime
 
   private request: CompileRequest;
   private schemas: Record<string, StructDef>;
+
+  private log = debug('malloydata:compiler_runtime');
 
   constructor(request: CompileRequest) {
     this.request = request;
@@ -61,7 +65,7 @@ export class CompilerRuntime
     | {structDef: StructDef; error?: undefined}
     | {error: string; structDef?: undefined}
   > => {
-    console.log('ERROR: fetchSchemaForSQLBlock() called.');
+    this.log('ERROR: fetchSchemaForSQLBlock() called.');
     throw new Error('Method not implemented.');
   };
 
@@ -69,7 +73,7 @@ export class CompilerRuntime
     _sql: string,
     _options?: unknown
   ): Promise<MalloyQueryData> => {
-    console.log('ERROR: runSQL() called.');
+    this.log('ERROR: runSQL() called.');
     throw new Error('Method not implemented.');
   };
 
@@ -84,14 +88,16 @@ export class CompilerRuntime
   canFetchSchemaAndRunStreamSimultaneously = async (): Promise<Boolean> =>
     false;
 
-  async fetchSchemaForTables(tables: string[]): Promise<{
+  async fetchSchemaForTables(tables: Record<string, string>): Promise<{
     schemas: Record<string, StructDef>;
     errors: Record<string, string>;
   }> {
-    console.log(JSON.stringify(tables));
-    for (const table of tables) {
-      if (!(table in this.schemas)) {
-        throw new Error(`Requested table (${table}) not found in schema data.`);
+    this.log('fetchSchemaForTables', JSON.stringify(tables));
+    for (const tableKey in tables) {
+      if (!(tableKey in this.schemas)) {
+        throw new Error(
+          `Requested table (${tableKey}) not found in schema data.`
+        );
       }
     }
     return {schemas: this.schemas, errors: {}};
@@ -101,16 +107,22 @@ export class CompilerRuntime
     schemas: Record<string, StructDef>;
     errors: Record<string, string>;
   }> {
-    console.log('ERROR: fetchSchemaForSQLBlocks() called.');
+    this.log('ERROR: fetchSchemaForSQLBlocks() called.');
     throw new Error('Method not implemented.');
   }
 
   lookupConnection = async (
     _connectionName?: string | undefined
   ): Promise<Connection> => {
-    console.log('lookupConnection() called.');
+    this.log('lookupConnection() called.');
     return this;
   };
+
+  async estimateQueryCost(_sqlCommand: string): Promise<QueryRunStats> {
+    return {
+      queryCostBytes: undefined,
+    };
+  }
 
   async close(): Promise<void> {}
 }

--- a/src/services/v1/compiler_urlreader.ts
+++ b/src/services/v1/compiler_urlreader.ts
@@ -31,7 +31,7 @@ import {CompileRequest} from './compiler_pb';
 export class CompilerURLReader implements URLReader {
   private request: CompileRequest;
 
-  private log = debug('mallloydata:compile_url_reader');
+  private log = debug('malloydata:compile_url_reader');
 
   constructor(request: CompileRequest) {
     this.request = request;


### PR DESCRIPTION
* Rework error handling for new error API
  * `error.log` is now `error.problems`
* Rework connection management for new connection API
  * Virtual connection now have unique objects to deal with the `getSchema...` methods no longer reliably including connection name.
  * This means we don't have to make any assumptions about which connection is being used for the SQL.
* Add `debug` for nicer logging.
  * To use, add `DEBUG='*'` or finer grained `DEBUG='malloy:*'` or `DEBUG='malloy:compiler_runtime'` before `npm start`, like `DEBUG='*' npm start` 