### PR TITLE
Use table keys safely

### DIFF
--- a/protos/services/v1/compiler.proto
+++ b/protos/services/v1/compiler.proto
@@ -57,6 +57,12 @@ message CompileDocument {
   string content = 2;
 }
 
+message TableSchema {
+  string key = 1;
+  string connection = 2;
+  string table = 3;
+}
+
 message CompilerRequest {
   enum Type {
     UNKNOWN = 0;
@@ -68,7 +74,7 @@ message CompilerRequest {
 
   CompilerRequest.Type type = 1;
   repeated string import_urls = 2;
-  repeated string table_schemas = 3;
+  repeated TableSchema table_schemas = 3;
   SqlBlock sql_block = 4;
   string connection = 5;
 
@@ -78,6 +84,7 @@ message CompilerRequest {
 message SqlBlock {
   string name = 1;
   string sql = 2;
+  string connection = 3;
 }
 
 message SqlBlockSchema {

--- a/src/services/v1/compiler_runtime.ts
+++ b/src/services/v1/compiler_runtime.ts
@@ -103,14 +103,6 @@ export class CompilerRuntime
     return {schemas: this.schemas, errors: {}};
   }
 
-  fetchSchemaForSQLBlocks(_sqlStructs: SQLBlock[]): Promise<{
-    schemas: Record<string, StructDef>;
-    errors: Record<string, string>;
-  }> {
-    this.log('ERROR: fetchSchemaForSQLBlocks() called.');
-    throw new Error('Method not implemented.');
-  }
-
   lookupConnection = async (
     _connectionName?: string | undefined
   ): Promise<Connection> => {

--- a/src/services/v1/streaming_compile_connection.ts
+++ b/src/services/v1/streaming_compile_connection.ts
@@ -54,7 +54,7 @@ export class StreamingCompileConnection implements Connection {
     } else {
       return {
         structDef: undefined,
-        error: `SQL Block schema missing: [[${block.name}]]{${block.selectStr}}`,
+        error: `SQL Block schema missing: [[${block.name}]]{${this.name}}{${block.selectStr}}`,
       };
     }
   };
@@ -89,21 +89,15 @@ export class StreamingCompileConnection implements Connection {
     for (const tableKey in tables) {
       const schema = this.table_schema_cache.get(tableKey);
       if (schema === undefined) {
-        result.errors[tableKey] = `No schema data available for {${tableKey}}`;
+        result.errors[
+          tableKey
+        ] = `No schema data available for {${tableKey}} {${this.name}} {${tables[tableKey]}}`;
       } else {
         result.schemas[tableKey] = schema;
       }
     }
 
     return result;
-  }
-
-  fetchSchemaForSQLBlocks(_sqlStructs: SQLBlock[]): Promise<{
-    schemas: Record<string, StructDef>;
-    errors: Record<string, string>;
-  }> {
-    this.log('ERROR: fetchSchemaForSQLBlocks() called.');
-    throw new Error('Method not implemented.');
   }
 
   addTableSchema = (tableKey: string, schema: StructDef): void => {


### PR DESCRIPTION
* Don't make assumptions about the content of table keys, as @christopherswenson warns they should not be parsed. Explicitly pass the key, connection and table values instead.
* Similarly pass the connection explicitly for SQL blocks.
* Remove unused method.
