### PR TITLE
Allow compiling a model without running a query.

### DIFF
--- a/protos/services/v1/compiler.proto
+++ b/protos/services/v1/compiler.proto
@@ -70,6 +70,7 @@ message CompilerRequest {
     TABLE_SCHEMAS = 2;
     SQL_BLOCK_SCHEMAS = 3;
     COMPLETE = 4;
+    ERROR = 5;
   }
 
   CompilerRequest.Type type = 1;

--- a/src/services/v1/compiler_runtime.ts
+++ b/src/services/v1/compiler_runtime.ts
@@ -40,13 +40,11 @@ export class CompilerRuntime
 {
   readonly name = 'compiler_runtime';
 
-  private request: CompileRequest;
   private schemas: Record<string, StructDef>;
 
   private log = debug('malloydata:compiler_runtime');
 
-  constructor(request: CompileRequest) {
-    this.request = request;
+  constructor(private request: CompileRequest) {
     try {
       this.schemas = JSON.parse(this.request.getSchema())['schemas'] as Record<
         string,


### PR DESCRIPTION
Allow errors to be associated with the model before compiling a query.