### PR TITLE
Add support for loading dialects as external modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ node_modules
 dist
 bin
 pkg
+scratch
 tsconfig.tsbuildinfo
 *_pb.d.ts
 *_pb.js

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@grpc/grpc-js": "^1.7.1",
         "@malloydata/malloy": "0.0.97",
         "@malloydata/render": "0.0.97",
+        "commander": "^11.1.0",
         "debug": "^4.3.4",
         "jsdom": "^22.1.0"
       },
@@ -2741,11 +2742,11 @@
       }
     },
     "node_modules/commander": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
       "engines": {
-        "node": ">= 10"
+        "node": ">=16"
       }
     },
     "node_modules/concat-map": {
@@ -2880,6 +2881,14 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-dsv/node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/d3-dsv/node_modules/iconv-lite": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
@@ -2941,6 +2950,14 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/d3-geo-projection/node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/d3-hierarchy": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@grpc/grpc-js": "^1.7.1",
     "@malloydata/malloy": "0.0.97",
     "@malloydata/render": "0.0.97",
+    "commander": "^11.1.0",
     "debug": "^4.3.4",
     "jsdom": "^22.1.0"
   },


### PR DESCRIPTION
Updated to use commander for argument parsing and cleaned up the handling a bit there.
Added section to load in a provided dialect option. Assumes the dialect is packaged in a module as the default export for dialect.